### PR TITLE
Add method: Parse(string input, IFormatProvider provider = null)

### DIFF
--- a/Source/QuantityTypes.Tests/Quantities/AngleTests.cs
+++ b/Source/QuantityTypes.Tests/Quantities/AngleTests.cs
@@ -54,5 +54,15 @@ namespace QuantityTypes.Tests
             var a = 90 * Angle.Degree;
             Assert.AreEqual("90,0°", a.ToString("0.0 [°]", CultureInfos.Norwegian));
         }
+
+        [Test]
+        public void ParseStringToAngleType()
+        {
+            const string Value = "50";
+            var parseMethod = typeof(Angle).GetMethod("Parse", new[] { Value.GetType(), typeof(IFormatProvider) });
+            Assert.IsNotNull(parseMethod);
+            var convertedValue = parseMethod.Invoke(null, new object[] { Value, CultureInfo.CurrentCulture });
+            Assert.AreEqual(50, (convertedValue is Angle ? (Angle)convertedValue : new Angle()).ConvertTo(Angle.Radian));
+        }
     }
 }

--- a/Source/QuantityTypes/Operators/Length.cs
+++ b/Source/QuantityTypes/Operators/Length.cs
@@ -65,17 +65,6 @@ namespace QuantityTypes
         /// <param name="x"> The x. </param>
         /// <param name="y"> The y. </param>
         /// <returns> The result of the operator. </returns>
-        public static double operator *(Length x, TypographicResolution y)
-        {
-            return x.Value * y.Value;
-        }
-
-        /// <summary>
-        ///     Implements the operator *.
-        /// </summary>
-        /// <param name="x"> The x. </param>
-        /// <param name="y"> The y. </param>
-        /// <returns> The result of the operator. </returns>
         public static Volume operator *(Length x, Area y)
         {
             return new Volume(x.Value * y.Value);

--- a/Source/QuantityTypes/Operators/Length.cs
+++ b/Source/QuantityTypes/Operators/Length.cs
@@ -65,6 +65,17 @@ namespace QuantityTypes
         /// <param name="x"> The x. </param>
         /// <param name="y"> The y. </param>
         /// <returns> The result of the operator. </returns>
+        public static double operator *(Length x, TypographicResolution y)
+        {
+            return x.Value * y.Value;
+        }
+
+        /// <summary>
+        ///     Implements the operator *.
+        /// </summary>
+        /// <param name="x"> The x. </param>
+        /// <param name="y"> The y. </param>
+        /// <returns> The result of the operator. </returns>
         public static Volume operator *(Length x, Area y)
         {
             return new Volume(x.Value * y.Value);

--- a/Source/QuantityTypes/Quantities/Acceleration.cs
+++ b/Source/QuantityTypes/Quantities/Acceleration.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Acceleration"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Acceleration Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Acceleration Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Acceleration value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Acceleration"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Acceleration Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Acceleration value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Acceleration.cs
+++ b/Source/QuantityTypes/Quantities/Acceleration.cs
@@ -156,7 +156,7 @@ namespace QuantityTypes
             return value;
         }
 
-		/// <summary>
+	/// <summary>
         /// Converts a string representation of a quantity in a specific culture-specific format.
         /// </summary>
         /// <param name="input">

--- a/Source/QuantityTypes/Quantities/Action.cs
+++ b/Source/QuantityTypes/Quantities/Action.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Action"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Action Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Action Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Action value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Action"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Action Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Action value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Action.cs
+++ b/Source/QuantityTypes/Quantities/Action.cs
@@ -142,7 +142,7 @@ namespace QuantityTypes
             return value;
         }
 
-		/// <summary>
+	/// <summary>
         /// Converts a string representation of a quantity in a specific culture-specific format.
         /// </summary>
         /// <param name="input">

--- a/Source/QuantityTypes/Quantities/AmountOfSubstance.cs
+++ b/Source/QuantityTypes/Quantities/AmountOfSubstance.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="AmountOfSubstance"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static AmountOfSubstance Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static AmountOfSubstance Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            AmountOfSubstance value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="AmountOfSubstance"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static AmountOfSubstance Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             AmountOfSubstance value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Angle.cs
+++ b/Source/QuantityTypes/Quantities/Angle.cs
@@ -182,12 +182,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Angle"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Angle Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Angle Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Angle value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Angle"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Angle Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Angle value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/AngularFrequency.cs
+++ b/Source/QuantityTypes/Quantities/AngularFrequency.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="AngularFrequency"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static AngularFrequency Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static AngularFrequency Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            AngularFrequency value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="AngularFrequency"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static AngularFrequency Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             AngularFrequency value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Area.cs
+++ b/Source/QuantityTypes/Quantities/Area.cs
@@ -182,12 +182,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Area"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Area Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Area Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Area value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Area"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Area Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Area value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Capacitance.cs
+++ b/Source/QuantityTypes/Quantities/Capacitance.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Capacitance"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Capacitance Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Capacitance Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Capacitance value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Capacitance"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Capacitance Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Capacitance value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Curvature.cs
+++ b/Source/QuantityTypes/Quantities/Curvature.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Curvature"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Curvature Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Curvature Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Curvature value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Curvature"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Curvature Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Curvature value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Density.cs
+++ b/Source/QuantityTypes/Quantities/Density.cs
@@ -224,12 +224,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Density"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Density Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Density Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Density value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Density"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Density Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Density value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/DynamicViscosity.cs
+++ b/Source/QuantityTypes/Quantities/DynamicViscosity.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="DynamicViscosity"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static DynamicViscosity Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static DynamicViscosity Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            DynamicViscosity value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="DynamicViscosity"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static DynamicViscosity Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             DynamicViscosity value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/ElectricCharge.cs
+++ b/Source/QuantityTypes/Quantities/ElectricCharge.cs
@@ -154,12 +154,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="ElectricCharge"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static ElectricCharge Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static ElectricCharge Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            ElectricCharge value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="ElectricCharge"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static ElectricCharge Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             ElectricCharge value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/ElectricCurrent.cs
+++ b/Source/QuantityTypes/Quantities/ElectricCurrent.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="ElectricCurrent"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static ElectricCurrent Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static ElectricCurrent Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            ElectricCurrent value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="ElectricCurrent"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static ElectricCurrent Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             ElectricCurrent value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/ElectricDipole.cs
+++ b/Source/QuantityTypes/Quantities/ElectricDipole.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="ElectricDipole"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static ElectricDipole Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static ElectricDipole Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            ElectricDipole value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="ElectricDipole"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static ElectricDipole Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             ElectricDipole value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/ElectricResistance.cs
+++ b/Source/QuantityTypes/Quantities/ElectricResistance.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="ElectricResistance"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static ElectricResistance Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static ElectricResistance Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            ElectricResistance value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="ElectricResistance"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static ElectricResistance Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             ElectricResistance value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/ElectricVoltage.cs
+++ b/Source/QuantityTypes/Quantities/ElectricVoltage.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="ElectricVoltage"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static ElectricVoltage Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static ElectricVoltage Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            ElectricVoltage value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="ElectricVoltage"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static ElectricVoltage Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             ElectricVoltage value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Energy.cs
+++ b/Source/QuantityTypes/Quantities/Energy.cs
@@ -154,12 +154,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Energy"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Energy Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Energy Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Energy value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Energy"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Energy Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Energy value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/FirstMomentOfArea.cs
+++ b/Source/QuantityTypes/Quantities/FirstMomentOfArea.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="FirstMomentOfArea"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static FirstMomentOfArea Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static FirstMomentOfArea Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            FirstMomentOfArea value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="FirstMomentOfArea"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static FirstMomentOfArea Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             FirstMomentOfArea value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Flow.cs
+++ b/Source/QuantityTypes/Quantities/Flow.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Flow"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Flow Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Flow Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Flow value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Flow"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Flow Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Flow value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Force.cs
+++ b/Source/QuantityTypes/Quantities/Force.cs
@@ -154,12 +154,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Force"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Force Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Force Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Force value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Force"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Force Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Force value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Fraction.cs
+++ b/Source/QuantityTypes/Quantities/Fraction.cs
@@ -168,12 +168,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Fraction"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Fraction Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Fraction Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Fraction value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Fraction"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Fraction Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Fraction value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Frequency.cs
+++ b/Source/QuantityTypes/Quantities/Frequency.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Frequency"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Frequency Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Frequency Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Frequency value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Frequency"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Frequency Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Frequency value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/FuelConsumption.cs
+++ b/Source/QuantityTypes/Quantities/FuelConsumption.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="FuelConsumption"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static FuelConsumption Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static FuelConsumption Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            FuelConsumption value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="FuelConsumption"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static FuelConsumption Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             FuelConsumption value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/FuelEconomy.cs
+++ b/Source/QuantityTypes/Quantities/FuelEconomy.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="FuelEconomy"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static FuelEconomy Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static FuelEconomy Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            FuelEconomy value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="FuelEconomy"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static FuelEconomy Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             FuelEconomy value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/HeatCapacity.cs
+++ b/Source/QuantityTypes/Quantities/HeatCapacity.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="HeatCapacity"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static HeatCapacity Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static HeatCapacity Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            HeatCapacity value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="HeatCapacity"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static HeatCapacity Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             HeatCapacity value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Illuminance.cs
+++ b/Source/QuantityTypes/Quantities/Illuminance.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Illuminance"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Illuminance Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Illuminance Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Illuminance value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Illuminance"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Illuminance Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Illuminance value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Inductance.cs
+++ b/Source/QuantityTypes/Quantities/Inductance.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Inductance"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Inductance Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Inductance Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Inductance value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Inductance"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Inductance Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Inductance value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/InformationEntropy.cs
+++ b/Source/QuantityTypes/Quantities/InformationEntropy.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="InformationEntropy"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static InformationEntropy Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static InformationEntropy Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            InformationEntropy value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="InformationEntropy"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static InformationEntropy Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             InformationEntropy value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/KinematicViscosity.cs
+++ b/Source/QuantityTypes/Quantities/KinematicViscosity.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="KinematicViscosity"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static KinematicViscosity Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static KinematicViscosity Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            KinematicViscosity value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="KinematicViscosity"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static KinematicViscosity Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             KinematicViscosity value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Length.cs
+++ b/Source/QuantityTypes/Quantities/Length.cs
@@ -294,12 +294,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Length"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Length Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Length Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Length value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Length"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Length Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Length value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/LinearMomentum.cs
+++ b/Source/QuantityTypes/Quantities/LinearMomentum.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="LinearMomentum"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static LinearMomentum Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static LinearMomentum Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            LinearMomentum value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="LinearMomentum"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static LinearMomentum Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             LinearMomentum value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Luminance.cs
+++ b/Source/QuantityTypes/Quantities/Luminance.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Luminance"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Luminance Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Luminance Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Luminance value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Luminance"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Luminance Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Luminance value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/LuminousFlux.cs
+++ b/Source/QuantityTypes/Quantities/LuminousFlux.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="LuminousFlux"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static LuminousFlux Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static LuminousFlux Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            LuminousFlux value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="LuminousFlux"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static LuminousFlux Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             LuminousFlux value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/LuminousIntensity.cs
+++ b/Source/QuantityTypes/Quantities/LuminousIntensity.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="LuminousIntensity"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static LuminousIntensity Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static LuminousIntensity Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            LuminousIntensity value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="LuminousIntensity"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static LuminousIntensity Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             LuminousIntensity value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/MagneticFlux.cs
+++ b/Source/QuantityTypes/Quantities/MagneticFlux.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="MagneticFlux"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static MagneticFlux Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static MagneticFlux Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            MagneticFlux value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="MagneticFlux"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static MagneticFlux Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             MagneticFlux value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/MagneticFluxDensity.cs
+++ b/Source/QuantityTypes/Quantities/MagneticFluxDensity.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="MagneticFluxDensity"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static MagneticFluxDensity Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static MagneticFluxDensity Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            MagneticFluxDensity value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="MagneticFluxDensity"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static MagneticFluxDensity Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             MagneticFluxDensity value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Mass.cs
+++ b/Source/QuantityTypes/Quantities/Mass.cs
@@ -210,12 +210,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Mass"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Mass Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Mass Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Mass value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Mass"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Mass Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Mass value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/MassMomentOfInertia.cs
+++ b/Source/QuantityTypes/Quantities/MassMomentOfInertia.cs
@@ -168,12 +168,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="MassMomentOfInertia"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static MassMomentOfInertia Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static MassMomentOfInertia Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            MassMomentOfInertia value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="MassMomentOfInertia"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static MassMomentOfInertia Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             MassMomentOfInertia value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Power.cs
+++ b/Source/QuantityTypes/Quantities/Power.cs
@@ -140,12 +140,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Power"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Power Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Power Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Power value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Power"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Power Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Power value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Pressure.cs
+++ b/Source/QuantityTypes/Quantities/Pressure.cs
@@ -224,12 +224,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Pressure"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Pressure Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Pressure Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Pressure value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Pressure"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Pressure Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Pressure value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/QuantityTemplate.tt
+++ b/Source/QuantityTypes/Quantities/QuantityTemplate.tt
@@ -182,7 +182,7 @@ namespace QuantityTypes
             return value;
         }
 
-		/// <summary>
+	/// <summary>
         /// Converts a string representation of a quantity in a specific culture-specific format.
         /// </summary>
         /// <param name="input">

--- a/Source/QuantityTypes/Quantities/QuantityTemplate.tt
+++ b/Source/QuantityTypes/Quantities/QuantityTemplate.tt
@@ -166,12 +166,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="<#= ClassName #>"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static <#= ClassName #> Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static <#= ClassName #> Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            <#= ClassName #> value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="<#= ClassName #>"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static <#= ClassName #> Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             <#= ClassName #> value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Radiation.cs
+++ b/Source/QuantityTypes/Quantities/Radiation.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Radiation"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Radiation Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Radiation Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Radiation value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Radiation"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Radiation Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Radiation value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/RadiationAbsorbedDose.cs
+++ b/Source/QuantityTypes/Quantities/RadiationAbsorbedDose.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="RadiationAbsorbedDose"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static RadiationAbsorbedDose Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static RadiationAbsorbedDose Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            RadiationAbsorbedDose value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="RadiationAbsorbedDose"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static RadiationAbsorbedDose Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             RadiationAbsorbedDose value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/RadiationEquivalentDose.cs
+++ b/Source/QuantityTypes/Quantities/RadiationEquivalentDose.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="RadiationEquivalentDose"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static RadiationEquivalentDose Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static RadiationEquivalentDose Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            RadiationEquivalentDose value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="RadiationEquivalentDose"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static RadiationEquivalentDose Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             RadiationEquivalentDose value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/RadiationExposure.cs
+++ b/Source/QuantityTypes/Quantities/RadiationExposure.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="RadiationExposure"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static RadiationExposure Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static RadiationExposure Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            RadiationExposure value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="RadiationExposure"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static RadiationExposure Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             RadiationExposure value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/RotationalStiffness.cs
+++ b/Source/QuantityTypes/Quantities/RotationalStiffness.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="RotationalStiffness"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static RotationalStiffness Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static RotationalStiffness Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            RotationalStiffness value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="RotationalStiffness"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static RotationalStiffness Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             RotationalStiffness value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/SecondMomentOfArea.cs
+++ b/Source/QuantityTypes/Quantities/SecondMomentOfArea.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="SecondMomentOfArea"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static SecondMomentOfArea Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static SecondMomentOfArea Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            SecondMomentOfArea value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="SecondMomentOfArea"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static SecondMomentOfArea Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             SecondMomentOfArea value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/SectionModulus.cs
+++ b/Source/QuantityTypes/Quantities/SectionModulus.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="SectionModulus"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static SectionModulus Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static SectionModulus Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            SectionModulus value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="SectionModulus"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static SectionModulus Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             SectionModulus value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/SolidAngle.cs
+++ b/Source/QuantityTypes/Quantities/SolidAngle.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="SolidAngle"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static SolidAngle Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static SolidAngle Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            SolidAngle value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="SolidAngle"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static SolidAngle Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             SolidAngle value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Stiffness.cs
+++ b/Source/QuantityTypes/Quantities/Stiffness.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Stiffness"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Stiffness Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Stiffness Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Stiffness value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Stiffness"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Stiffness Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Stiffness value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/TemperatureDifference.cs
+++ b/Source/QuantityTypes/Quantities/TemperatureDifference.cs
@@ -154,12 +154,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="TemperatureDifference"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static TemperatureDifference Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static TemperatureDifference Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            TemperatureDifference value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="TemperatureDifference"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static TemperatureDifference Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             TemperatureDifference value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Time.cs
+++ b/Source/QuantityTypes/Quantities/Time.cs
@@ -196,12 +196,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Time"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Time Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Time Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Time value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Time"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Time Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Time value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/TimeSquared.cs
+++ b/Source/QuantityTypes/Quantities/TimeSquared.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="TimeSquared"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static TimeSquared Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static TimeSquared Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            TimeSquared value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="TimeSquared"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static TimeSquared Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             TimeSquared value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Torque.cs
+++ b/Source/QuantityTypes/Quantities/Torque.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Torque"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Torque Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Torque Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Torque value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Torque"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Torque Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Torque value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/TypographicLength.cs
+++ b/Source/QuantityTypes/Quantities/TypographicLength.cs
@@ -182,12 +182,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="TypographicLength"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static TypographicLength Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static TypographicLength Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            TypographicLength value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="TypographicLength"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static TypographicLength Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             TypographicLength value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/TypographicResolution.cs
+++ b/Source/QuantityTypes/Quantities/TypographicResolution.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="TypographicResolution"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static TypographicResolution Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static TypographicResolution Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            TypographicResolution value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="TypographicResolution"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static TypographicResolution Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             TypographicResolution value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Velocity.cs
+++ b/Source/QuantityTypes/Quantities/Velocity.cs
@@ -154,12 +154,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Velocity"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Velocity Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Velocity Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Velocity value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Velocity"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Velocity Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Velocity value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/VelocitySquared.cs
+++ b/Source/QuantityTypes/Quantities/VelocitySquared.cs
@@ -126,12 +126,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="VelocitySquared"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static VelocitySquared Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static VelocitySquared Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            VelocitySquared value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="VelocitySquared"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static VelocitySquared Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             VelocitySquared value;
             if (!unitProvider.TryParse(input, provider, out value))

--- a/Source/QuantityTypes/Quantities/Volume.cs
+++ b/Source/QuantityTypes/Quantities/Volume.cs
@@ -154,12 +154,37 @@ namespace QuantityTypes
         /// <returns>
         /// A <see cref="Volume"/> that represents the quantity in <paramref name="input" />. 
         /// </returns>
-        public static Volume Parse(string input, IFormatProvider provider = null, IUnitProvider unitProvider = null)
+        public static Volume Parse(string input, IFormatProvider provider, IUnitProvider unitProvider)
         {
             if (unitProvider == null)
             {
                 unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
             }
+
+            Volume value;
+            if (!unitProvider.TryParse(input, provider, out value))
+            {
+                throw new FormatException("Invalid format.");
+            }
+
+            return value;
+        }
+
+		/// <summary>
+        /// Converts a string representation of a quantity in a specific culture-specific format.
+        /// </summary>
+        /// <param name="input">
+        /// A string that contains the quantity to convert. 
+        /// </param>
+        /// <param name="provider">
+        /// An object that supplies culture-specific formatting information about <paramref name="input" />. If not specified, the culture of the default <see cref="UnitProvider" /> is used. 
+        /// </param>
+        /// <returns>
+        /// A <see cref="Volume"/> that represents the quantity in <paramref name="input" />. 
+        /// </returns>
+        public static Volume Parse(string input, IFormatProvider provider = null)
+        {
+            var unitProvider = provider as IUnitProvider ?? UnitProvider.Default;
 
             Volume value;
             if (!unitProvider.TryParse(input, provider, out value))


### PR DESCRIPTION
In order to fix issue #15.
We failed to get method Parse with arguments(string and IFormatProvider)
in PropertyTool to parse a string.

So I just add this method and don't use optional arguments for
Parse(string input, IFormatProvider provider, IUnitProvider
unitProvider)
