### PR TITLE
Switch PCL project to profile 328

### DIFF
--- a/Source/QuantityTypes/QuantityTypes.csproj
+++ b/Source/QuantityTypes/QuantityTypes.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>QuantityTypes</RootNamespace>
     <AssemblyName>QuantityTypes</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OldToolsVersion>4.0</OldToolsVersion>


### PR DESCRIPTION
Hi Oystein,

I noticed that the PCL version of the *QuantityTypes* library is currently targeting profile 136. I thought it would be good to use profile 328 instead, which supports all the targets of 136, **plus** *Windows Phone 8.1* (non-Silverlight).

To facilitate, I have created a pull request for this. If you approve of the change, please feel free to pull it in.

Best regards,
Anders @ Cureos