### PR TITLE
PR for issue #23 - please adjust the assembly/nuget version to a value that reflects the breaking changes

### DIFF
--- a/Source/QuantityTypes.Tests/Quantities/DensityTests.cs
+++ b/Source/QuantityTypes.Tests/Quantities/DensityTests.cs
@@ -21,7 +21,7 @@ namespace QuantityTypes.Tests
         public void Constructors()
         {
             Assert.AreEqual(2, new Density(2).Value);
-            Assert.AreEqual(2, new Density("2Kg/M^3").Value);
+            Assert.AreEqual(2, new Density("2kg/m^3").Value);
         }
 
         [Test]
@@ -39,10 +39,23 @@ namespace QuantityTypes.Tests
         }
 
         [Test]
+        [ExpectedException(typeof(FormatException))]
+        public void Parse_InvalidUnitPrefixCaseString()
+        {
+            Assert.AreEqual(2, Density.Parse("2Kg/m^3").Value, "wrong case in unit prefix");
+        }
+
+        [Test]
+        [ExpectedException(typeof(FormatException))]
+        public void Parse_InvalidUnitCaseString()
+        {
+            Assert.AreEqual(2, Density.Parse("2kg/M^3").Value, "wrong case");
+        }
+
+        [Test]
         public void Parse_ValidStrings()
         {
             Assert.AreEqual(2, Density.Parse("2kg/m^3").Value, "correct unit");
-            Assert.AreEqual(2, Density.Parse("2Kg/M^3").Value, "wrong case");
             Assert.AreEqual(2, Density.Parse("2").Value, "no unit");
         }
 

--- a/Source/QuantityTypes/Quantities/Units.csv
+++ b/Source/QuantityTypes/Quantities/Units.csv
@@ -5,6 +5,7 @@
 // http://en.wikipedia.org/wiki/Quantity
 // http://en.wikipedia.org/wiki/Physical_quantities
 // http://en.wikipedia.org/wiki/Phenomenon
+// http://en.wikipedia.org/wiki/Unit_prefix
 
 // Length
 Length,Metre,m,1
@@ -72,6 +73,9 @@ Time,Millisecond,ms,1e-3
 
 // Frequency
 Frequency,Hertz,Hz,1
+Frequency,Kilohertz,kHz,1e3
+Frequency,Megahertz,MHz,1e6
+Frequency,Gigahertz,GHz,1e9
 Frequency,RevolutionsPerMinute,rpm,1.0 / 60
 
 AngularFrequency,RadiansPerSecond,rad/s,1
@@ -120,7 +124,8 @@ Energy,KilowattHour,kW*h,3600000
 // Power or heat flow rate
 Power,Watt,W,1
 Power,Milliwatt,mW,1e-3
-Power,KiloWatt,kW,1e3
+Power,Kilowatt,kW,1e3
+Power,Megawatt,MW,1e6
 Power,HorsePower,hp,735.49875
 
 // Action
@@ -160,8 +165,8 @@ ElectricVoltage,Microvolt,µV,1e-6
 // Electric resistance
 ElectricResistance,Ohm,Ω,1
 ElectricResistance,Milliohm,mΩ,1e-3
-ElectricResistance,Killoohm,kΩ,1e3
-//ElectricResistance,Megaohm,MΩ,1e6//does not work:unit is case insensitive
+ElectricResistance,Kiloohm,kΩ,1e3
+ElectricResistance,Megaohm,MΩ,1e6
 
 // Capacitance
 Capacitance,Farad,F,1
@@ -175,6 +180,7 @@ MagneticFluxDensity,Tesla,T,1
 
 // Inductance
 Inductance,Henry,H,1
+Inductance,Millihenry,mH,1e-3
 
 // Temperature (special case)
 

--- a/Source/QuantityTypes/UnitProvider/UnitProvider.cs
+++ b/Source/QuantityTypes/UnitProvider/UnitProvider.cs
@@ -285,7 +285,7 @@ namespace QuantityTypes
             var type = unit.GetType();
             if (!this.units.ContainsKey(type))
             {
-                this.units.Add(type, new Dictionary<string, IQuantity>(StringComparer.OrdinalIgnoreCase));
+                this.units.Add(type, new Dictionary<string, IQuantity>());
             }
 
             if (this.units[type].ContainsKey(name))


### PR DESCRIPTION
breaking change: unit prefix is now case-sensitive to allow m(illi) and M(ega) (see issue #23), changed unit-tests accordingly, breaking change: corrected two typos in unit-names that were added in last commit, added some unit prefixes for existing units